### PR TITLE
[Precogs Alert] Sensitive Information Exposure detected (CWE-200, Risk: High)

### DIFF
--- a/access.sh
+++ b/access.sh
@@ -20,17 +20,25 @@ grafana_user="admin"
 grafana_password=$(kubectl get secret stable-grafana -n prometheus -o jsonpath="{.data.admin-password}" | base64 --decode)
 
 # Print or use these variables
+# FIX: Do NOT print sensitive credentials to stdout. Instead, write them to a protected file with restricted permissions, or instruct the user to retrieve them securely.
 echo "------------------------"
 echo "ArgoCD URL: $argo_url"
 echo "ArgoCD User: $argo_user"
-echo "ArgoCD Initial Password: $argo_initial_password" | head -n 1
+echo "ArgoCD Initial Password: [REDACTED]" # FIX: Do not print the actual password
 echo
 echo "Prometheus URL: $prometheus_url":9090
 echo
 echo "Grafana URL: $grafana_url"
 echo "Grafana User: $grafana_user"
-echo "Grafana Password: $grafana_password"
+echo "Grafana Password: [REDACTED]" # FIX: Do not print the actual password
 echo "------------------------"
+
+# Optionally, write credentials to a file with restricted permissions:
+# credentials_file="./credentials.txt"
+# umask 077
+# echo "ArgoCD Initial Password: $argo_initial_password" > "$credentials_file"
+# echo "Grafana Password: $grafana_password" >> "$credentials_file"
+# echo "Credentials written to $credentials_file with restricted permissions."
 
 # Run below commands
 # chmod a+x access.sh


### PR DESCRIPTION
### Vulnerability Details

  - **File Path:** `access.sh`
  - **Vulnerability Type:** Sensitive Information Exposure
  - **Risk Level:** High
  
  **Explanation:**  
  This script prints sensitive credentials (ArgoCD and Grafana admin passwords) directly to standard output. If the script is run in a shared environment, or if the output is logged (e.g., via shell history, CI/CD logs, or terminal scrollback), unauthorized users may obtain admin credentials for critical infrastructure components. The root cause is the direct echoing of secrets to the console without any access control or redaction. 

attackScenario: An attacker with access to the terminal session, shell history, or CI/CD logs where this script is executed can retrieve the ArgoCD and Grafana admin passwords, enabling unauthorized access to these services and potentially compromising the entire cluster.

potentialImpact: Compromise of admin credentials for ArgoCD and Grafana can lead to full control over deployment pipelines, monitoring, and potentially the underlying Kubernetes cluster (Confidentiality and Integrity breach, with possible Availability impact if services are modified or deleted).
  
  Please review and address the issue accordingly.